### PR TITLE
Update for ubuntu trusty and Java 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ MAINTAINER Zach Latta <zach@zachlatta.com>
 RUN apt-get update
 RUN apt-get upgrade -y
 
-RUN apt-get install python-software-properties -y
+RUN apt-get install software-properties-common -y
 
 RUN add-apt-repository ppa:webupd8team/java -y
 RUN apt-get update
 
-RUN echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-get install -y oracle-java7-installer
+RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+RUN apt-get install -y oracle-java8-installer


### PR DESCRIPTION
Switch python-software-properties with software-properties-common and oracle-java7-installer with oracle-java8-installer.
